### PR TITLE
ci(release): externalize release notes generator into .github/scripts…

### DIFF
--- a/.github/scripts/generate-release-notes.js
+++ b/.github/scripts/generate-release-notes.js
@@ -1,0 +1,104 @@
+const fs = require('fs');
+const { execSync } = require('child_process');
+
+function extractFromChangelog(changelog, headerMatch) {
+  const idx = changelog.indexOf(headerMatch);
+  if (idx === -1) return [];
+  const nextIdx = changelog.indexOf('\n## [', idx + headerMatch.length);
+  const section = (nextIdx === -1) ? changelog.slice(idx) : changelog.slice(idx, nextIdx);
+  return section.split(/\r?\n/)
+    .map(l => l.trim())
+    .filter(Boolean)
+    .filter(l => l.startsWith('-'))
+    .map(l => l.replace(/^[-\s]+/, ''));
+}
+
+function writeOutput(body) {
+  const outPath = process.env.GITHUB_OUTPUT;
+  if (outPath) {
+    const marker = 'END_OF_RELEASE_BODY';
+    const safeBody = body.replace(new RegExp(marker, 'g'), marker + '_REPLACED');
+    fs.appendFileSync(outPath, `body<<${marker}\n${safeBody}\n${marker}\n`);
+  } else {
+    // Fallback to stdout
+    console.log(body);
+  }
+}
+
+async function main() {
+  // Determine tag
+  const ref = process.env.GITHUB_REF || process.env.GITHUB_REF_NAME || '';
+  const tag = ref && ref.startsWith('refs/tags/') ? ref.replace('refs/tags/', '') : ref;
+  const ver = tag && tag.startsWith('v') ? tag.slice(1) : tag;
+
+  let entries = [];
+  try {
+    const changelog = fs.readFileSync('CHANGELOG.md', 'utf8');
+    if (ver) entries = extractFromChangelog(changelog, `## [${ver}]`);
+    if (!entries.length) entries = extractFromChangelog(changelog, '## [Unreleased]');
+  } catch (e) {
+    // ignore
+  }
+
+  if (!entries.length) {
+    try {
+      const lastTag = execSync('git describe --tags --abbrev=0 $(git rev-list --tags --max-count=1) || true', { encoding: 'utf8' }).trim();
+      let cmd;
+      if (lastTag && tag) cmd = `git log ${lastTag}..${tag} --pretty=format:'- %s (%an)' -n 200`;
+      else if (tag) cmd = `git log ${tag} -n 200 --pretty=format:'- %s (%an)'`;
+      else cmd = `git log -n 200 --pretty=format:'- %s (%an)'`;
+      const out = execSync(cmd, { encoding: 'utf8' });
+      entries = out.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+    } catch (e) {
+      entries = ['No release notes available.'];
+    }
+  }
+
+  const categories = { Added: [], Changed: [], Fixed: [], Docs: [], CI: [], Other: [] };
+  for (const e of entries) {
+    const low = e.toLowerCase();
+    if (/\b(feat|add|added|new)\b/.test(low)) categories.Added.push(e);
+    else if (/\b(fix|bug|fixes|patched?)\b/.test(low)) categories.Fixed.push(e);
+    else if (/\b(doc|docs|documentation)\b/.test(low)) categories.Docs.push(e);
+    else if (/\b(ci|workflow|actions|github)\b/.test(low)) categories.CI.push(e);
+    else if (/\b(refactor|change|changed|upgrade|update|improve)\b/.test(low)) categories.Changed.push(e);
+    else categories.Other.push(e);
+  }
+
+  let date = new Date().toISOString().slice(0, 10);
+  try {
+    if (tag) {
+      const dt = execSync(`git log -1 --format=%cd ${tag}`, { encoding: 'utf8' }).trim();
+      if (dt) date = new Date(dt).toISOString().slice(0, 10);
+    }
+  } catch (e) {
+    // ignore
+  }
+
+  const lines = [];
+  lines.push(`## ${tag || 'untagged'} — ${date}`);
+  lines.push('');
+
+  const first = entries.find(Boolean) || '';
+  if (first) {
+    lines.push('### Highlights');
+    lines.push(`- ${first}`);
+    lines.push('');
+  }
+
+  for (const [name, list] of Object.entries(categories)) {
+    if (!list.length) continue;
+    lines.push(`### ${name}`);
+    for (const item of list) lines.push(`- ${item}`);
+    lines.push('');
+  }
+
+  lines.push('---');
+  const repo = process.env.GITHUB_REPOSITORY || '';
+  lines.push(`Full changelog: https://github.com/${repo}/blob/master/CHANGELOG.md`);
+
+  const body = lines.join('\n');
+  writeOutput(body);
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,8 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -57,53 +58,15 @@ jobs:
         run: |
           echo "Files in dist:"; ls -la dist || true; find dist -maxdepth 3 -type f -print || true
 
-      - name: Generate release notes
-        id: generate_notes
-        uses: actions/github-script@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          script: |
-            const fs = require('fs');
-            const { execSync } = require('child_process');
-            // Robustly determine tag name from various environment sources
-            const ref = (typeof github !== 'undefined' && github.context && github.context.ref)
-              ? github.context.ref
-              : (process.env.GITHUB_REF || process.env.GITHUB_REF_NAME || '');
-            const tag = ref && ref.startsWith('refs/tags/') ? ref.replace('refs/tags/', '') : ref;
-            const ver = tag && tag.startsWith('v') ? tag.slice(1) : tag;
-            let body = '';
-            try {
-              if (ver) {
-                const changelog = fs.readFileSync('CHANGELOG.md', 'utf8');
-                const header = '## [' + ver + ']';
-                const idx = changelog.indexOf(header);
-                if (idx !== -1) {
-                  // find next section header starting with '\n## [' after the matched one
-                  const nextIdx = changelog.indexOf('\n## [', idx + header.length);
-                  body = (nextIdx === -1) ? changelog.slice(idx) : changelog.slice(idx, nextIdx);
-                  body = body.trim();
-                }
-              }
-            } catch (err) {
-              // ignore and fallback to git log
-            }
-            if (!body) {
-              try {
-                body = execSync("git --no-pager log --pretty=format:'- %s (%an)' -n 200", { encoding: 'utf8' });
-              } catch (err) {
-                body = 'No commit notes generated.';
-              }
-            }
-            // Write multiline output reliably to GITHUB_OUTPUT for downstream steps
-            const outPath = process.env.GITHUB_OUTPUT;
-            if (outPath) {
-              // Guard against the unlikely presence of EOF marker in body
-              const marker = 'END_OF_RELEASE_BODY';
-              const safeBody = body.replace(new RegExp(marker, 'g'), marker + '_REPLACED');
-              fs.appendFileSync(outPath, `body<<${marker}\n${safeBody}\n${marker}\n`);
-            } else {
-              // Fallback: set as console result (github-script will expose as 'result')
-              return { body };
-            }
+          node-version: '18'
+
+      - name: Run release notes generator
+        id: generate_notes
+        run: |
+          node .github/scripts/generate-release-notes.js
 
       - name: Create release and upload artifacts
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
…/generate-release-notes.js and call from workflow

**Summary:**

Move release-notes generation out of the workflow YAML into generate-release-notes.js.
Update release.yml to run the external Node script (via actions/setup-node) and use its output as the release body.
Keeps release formatting consistent: Highlights / Added / Changed / Fixed / Docs / CI / Other, with fallback to CHANGELOG or git log.

**Why:**

Easier to edit and test the notes-generator without modifying workflow YAML.
Simpler debugging and maintainability for complex JS logic.
Enables ad-hoc tweaks to formatting or logic by editing a single script file.

**Changes:**

Added generate-release-notes.js
Updated release.yml to call the script and attach artifacts to the release.
(No production code changes.)

**Testing / verification:**

On merge, pushing a tag vX.Y.Z will run the workflow and create a Release whose body is generated by the script.
Locally you can run: node .github/scripts/generate-release-notes.js to preview output.
Workflow steps include artifact upload/download, so built artifacts are attached to the Release.

**Checklist:**

 Script added under scripts
 Workflow updated to run Node and call script
 Confirm CI runs successfully on next tag push (or re-run existing failed run)

**Notes for reviewer:**

Review generate-release-notes.js for desired formatting rules and any sensitive assumptions about repo structure.
If you prefer a different categorization or template, suggest changes in the script (it's safe to modify without altering YAML).